### PR TITLE
Исправление Notice: Undefined index: SERVER_PROTOCOL

### DIFF
--- a/src/client.php
+++ b/src/client.php
@@ -149,8 +149,8 @@ class ErrorCatcher
 
         // Stack Trace
         $trace = self::getStackTrace($trace, $file, $line);
-
-        $protocol = strpos(strtolower($_SERVER['SERVER_PROTOCOL']), 'https') === false ? 'http' : 'https';
+        $serverProtocol = strtolower(self::getEnvValue($_SERVER, 'SERVER_PROTOCOL'));
+        $protocol = strpos($serverProtocol, 'https') === false ? 'http' : 'https';
         $host = self::getEnvValue($_SERVER, 'HTTP_HOST');
         $script = self::getEnvValue($_SERVER, 'SCRIPT_NAME');
         $url = $protocol . '://' . $host . $script;


### PR DESCRIPTION
Во время ошибок при выполнении PHP CLI в консоли появляется ошибка `Notice: Undefined index: SERVER_PROTOCOL`.